### PR TITLE
feat: set dependabot to run daily but with 0 pr's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,5 @@ updates:
     - package-ecosystem: 'npm' # See documentation for possible values
       directory: '/' # Location of package manifests
       schedule:
-          interval: 'weekly'
+          interval: 'daily'
+      open-pull-requests-limit: 0


### PR DESCRIPTION
Fixes #212 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency management settings to change update intervals to daily and limit open pull requests to 0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->